### PR TITLE
Add readconvert command to GenericIPBusDevice

### DIFF
--- a/src/GenericIPBus_device/GenericIPBus_device.cc
+++ b/src/GenericIPBus_device/GenericIPBus_device.cc
@@ -59,7 +59,11 @@ void GenericIPBusDevice::LoadCommandList(){
 	       &GenericIPBusDevice::RegisterAutoComplete);
     AddCommandAlias("ro","readoffset");
 
-
+	AddCommand("readconvert",&GenericIPBusDevice::ReadConvert,
+	     "Read and convert register\n" \
+	     "Usage: \n"                           \
+	     "  readconvert reg\n",
+	     &GenericIPBusDevice::RegisterAutoComplete);
 
     AddCommand("write",&GenericIPBusDevice::Write,
 	       "Write to GenericIPBus\n"           \


### PR DESCRIPTION
This PR contains an update to add the new `readconvert` command to a Generic IPBus Device class. The functionality for this command is implemented by `BUTool::RegisterHelperIO` class, under the branch `release/v2.0`.